### PR TITLE
Fix anchor text in link to Kin's GitHub profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ layout: default
 
 <p><i class="fa fa-globe"></i> <a href="http://kinlane.com/blog">personal blog</a>, <a href="http://apievangelist.com">api evangelist</a></p>
 <p><i class="fa fa-twitter"></i> <a href="https://twitter.com/kinlane">@kinlane</a>, <a href="https://twitter.com/apievangelist">@apievangelist</a></p>
-<p><i class="fa fa-github"></i> <a href="https://github.com/kinlane">audreywatters</a></p>
+<p><i class="fa fa-github"></i> <a href="https://github.com/kinlane">kinlane</a></p>
 
 <br />
 


### PR DESCRIPTION
Hi,

I stumbled on Tech Gypsies via @audreywatters post on [Amazon's Plans for OER](http://hackeducation.com/2016/02/17/amazon-oer) (great post BTW), and found a typo in the anchor text for @kinlane's GitHub profile on your website.

Cheers.